### PR TITLE
Dependency Fix - Nested Quotes - `--key="value"` format

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,18 @@ string-argv parses a string into an argument array to mimic process.argv.
 This is useful when testing Command Line Utilities that you want to pass arguments to and is the opposite of what the other argv utilities do.
 
 #Installation
+
 ```
 npm install string-argv --save
 ```
+
 #Usage
-```
-var util = require('../index');
-var args = util.parseArgsStringToArgv(
-    '-testing test -valid=true --quotes "test quotes"', 
-    'node', 
+
+```js
+var stringArgv = require('string-argv');
+var args = stringArgv.parseArgsStringToArgv(
+    '-testing test -valid=true --quotes "test quotes" "nested \'quotes\'" --key="some value" --title="Peter\'s Friends"',
+    'node',
     'testing.js'
 );
 
@@ -25,7 +28,10 @@ console.log(args);
   'test',
   '-valid=true',
   '--quotes',
-  'test quotes' ]
+  'test quotes',
+  'nested \'quotes\'',
+  '--key="some value"',
+  '--title="Peter\'s Friends"' ]
   **/
 ```
 

--- a/index.js
+++ b/index.js
@@ -4,10 +4,15 @@ module.exports.parseArgsStringToArgv = parseArgsStringToArgv;
 
 function parseArgsStringToArgv(value, env, file) {
     //[^\s'"] Match if not a space ' or "
-    //+|['"] or Match ' or "
-    //([^'"]*) Match anything that is not ' or "
-    //['"] Close match if ' or "
-    var myRegexp = /[^\s'"]+|['"]([^'"]*)['"]/gi;
+
+    //+|['] or Match '
+    //([^']*) Match anything that is not '
+    //['] Close match if '
+
+    //+|["] or Match "
+    //([^"]*) Match anything that is not "
+    //["] Close match if "
+    var myRegexp = /[^\s'"]+|[']([^']*?)[']|["]([^"]*?)["]/gi;
     var myString = value;
     var myArray = [
     ];
@@ -24,7 +29,7 @@ function parseArgsStringToArgv(value, env, file) {
         if (match !== null) {
             //Index 1 in the array is the captured group if it exists
             //Index 0 is the matched text, which we use if no captured group exists
-            myArray.push(match[1] ? match[1] : match[0]);
+            myArray.push(match[2] ? match[2] : (match[1]?match[1]:match[0]));
         }
     } while (match !== null);
 

--- a/index.js
+++ b/index.js
@@ -3,16 +3,13 @@
 module.exports.parseArgsStringToArgv = parseArgsStringToArgv;
 
 function parseArgsStringToArgv(value, env, file) {
-    //[^\s'"] Match if not a space ' or "
+    //([^\s'"]+(['"])([^\2]*?)\2) Match `text"quotes text"`
 
-    //+|['] or Match '
-    //([^']*) Match anything that is not '
-    //['] Close match if '
+    //[^\s'"] or Match if not a space ' or "
 
-    //+|["] or Match "
-    //([^"]*) Match anything that is not "
-    //["] Close match if "
-    var myRegexp = /[^\s'"]+|[']([^']*?)[']|["]([^"]*?)["]/gi;
+    //(['"])([^\4]*?)\4 or Match "quoted text" without quotes
+    // `\2` and `\4` are a backreference to the quote style (' or ") captured
+    var myRegexp = /([^\s'"]+(['"])([^\2]*?)\2)|[^\s'"]+|(['"])([^\4]*?)\4/gi;
     var myString = value;
     var myArray = [
     ];
@@ -29,7 +26,7 @@ function parseArgsStringToArgv(value, env, file) {
         if (match !== null) {
             //Index 1 in the array is the captured group if it exists
             //Index 0 is the matched text, which we use if no captured group exists
-            myArray.push(match[2] ? match[2] : (match[1]?match[1]:match[0]));
+            myArray.push(match[1] || match[5] || match[0]);
         }
     } while (match !== null);
 

--- a/package.json
+++ b/package.json
@@ -25,9 +25,7 @@
     },
     "homepage": "https://github.com/mccormicka/string-argv",
     "readmeFilename": "README.md",
-    "dependencies": {
-        "bunyan": "~0.22.1"
-    },
+    "dependencies": {},
     "devDependencies": {
         "grunt": "0.4.1",
         "jasmine-node": "https://github.com/mccormicka/jasmine-node/archive/exclusive-tests.tar.gz",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "logger"
     ],
     "scripts": {
-        "test": "./node_modules/jasmine-node/bin/jasmine-node test/ --verbose --color --captureExceptions"
+        "test": "jasmine-node test/ --verbose --color --captureExceptions"
     },
     "main": "index",
     "engines": {

--- a/test/Index.spec.js
+++ b/test/Index.spec.js
@@ -93,5 +93,19 @@ describe('SHOULD', function () {
             done();
         });
 
+        it('a complex key value with quotes', function (done) {
+            var results = util.parseArgsStringToArgv('--name=\'Phil Taylor\' --title="Peter\'s Friends"');
+            expect(results.length).toBe(2);
+            expect(results[0]).toEqual('--name=\'Phil Taylor\'');
+            expect(results[1]).toEqual('--title="Peter\'s Friends"');
+            done();
+        });
+
+        it('a complex key value with nested quotes', function (done) {
+            var results = util.parseArgsStringToArgv('--name=\'Phil "The Power" Taylor\'');
+            expect(results.length).toBe(1);
+            expect(results[0]).toEqual('--name=\'Phil "The Power" Taylor\'');
+            done();
+        });
     });
 });

--- a/test/Index.spec.js
+++ b/test/Index.spec.js
@@ -80,10 +80,18 @@ describe('SHOULD', function () {
             expect(results[2]).toEqual('-valid=true');
             expect(results[3]).toEqual('--quotes');
             expect(results[4]).toEqual('test quotes');
-            console.log(results);
             done();
         });
 
+        it('a complex string with nested quotes', function (done) {
+            var results = util.parseArgsStringToArgv('--title "Peter\'s Friends" --name \'Phil "The Power" Taylor\'');
+            expect(results.length).toBe(4);
+            expect(results[0]).toEqual("--title");
+            expect(results[1]).toEqual("Peter's Friends");
+            expect(results[2]).toEqual("--name");
+            expect(results[3]).toEqual('Phil "The Power" Taylor');
+            done();
+        });
 
     });
 });


### PR DESCRIPTION
This is a pull request combining #1 and #3 (Thanks to @chocolateboy and @gliviu)
Closes #1
Fixes #2
Closes #3 

I combined both changes and added another format `--key="some value"`
I updated the documentation accordingly.
I combined all these changes because this project doesn't seem to be maintained.

I wanted a valid project to do my work, so I can do `npm install cellule/string-argv --save`
If this gets merged, I would love to be able to install from npm again.
If it doesn't get merged after a while, I might fork it and publish to npm under a different name (there is no license in the project so it's hard to tell if I can do this or not #4)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mccormicka/string-argv/5)
<!-- Reviewable:end -->
