### PR TITLE
Provide both esm and commonjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 index.js
 index.d.ts
+commonjs/index.js

--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,5 @@ test/
 *.ts
 !*.d.ts
 tsconfig.json
+tsconfig.base.json
+tsconfig.commonjs.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.1 (2022-09-16)
+- Now provides both esm and cjs builds
+- Update TypeScript to 4.8.3
+
 ## v0.3.0 (2019-04-16)
 **Dev Experience Changes**
 - Project now compiled with TypeScript and provides typings

--- a/commonjs/package.json
+++ b/commonjs/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,5 @@
-
-export { parseArgsStringToArgv as default, parseArgsStringToArgv };
-function parseArgsStringToArgv(
+export { parseArgsStringToArgv };
+export default function parseArgsStringToArgv(
   value: string,
   env?: string,
   file?: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,159 @@
 {
   "name": "string-argv",
   "version": "0.3.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "string-argv",
+      "version": "0.3.0",
+      "license": "MIT",
+      "devDependencies": {
+        "jasmine": "^4.4.0",
+        "typescript": "^4.8.3"
+      },
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/jasmine": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-4.4.0.tgz",
+      "integrity": "sha512-xrbOyYkkCvgduNw7CKktDtNb+BwwBv/zvQeHpTkbxqQ37AJL5V4sY3jHoMIJPP/hTc3QxLVwOyxc87AqA+kw5g==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.6",
+        "jasmine-core": "^4.4.0"
+      },
+      "bin": {
+        "jasmine": "bin/jasmine.js"
+      }
+    },
+    "node_modules/jasmine-core": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.4.0.tgz",
+      "integrity": "sha512-+l482uImx5BVd6brJYlaHe2UwfKoZBqQfNp20ZmdNfsjGFTemGfqHLsXjKEW23w9R/m8WYeFc9JmIgjj6dUtAA==",
+      "dev": true
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    }
+  },
   "dependencies": {
     "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
     "brace-expansion": {
@@ -23,31 +169,25 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
-    },
-    "exit": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
@@ -55,7 +195,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "requires": {
         "once": "^1.3.0",
@@ -63,32 +203,31 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
     "jasmine": {
-      "version": "2.99.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.99.0.tgz",
-      "integrity": "sha1-jKctEC5jm4Z8ZImFbg4YqceqQrc=",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-4.4.0.tgz",
+      "integrity": "sha512-xrbOyYkkCvgduNw7CKktDtNb+BwwBv/zvQeHpTkbxqQ37AJL5V4sY3jHoMIJPP/hTc3QxLVwOyxc87AqA+kw5g==",
       "dev": true,
       "requires": {
-        "exit": "^0.1.2",
-        "glob": "^7.0.6",
-        "jasmine-core": "~2.99.0"
+        "glob": "^7.1.6",
+        "jasmine-core": "^4.4.0"
       }
     },
     "jasmine-core": {
-      "version": "2.99.1",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.99.1.tgz",
-      "integrity": "sha1-5kAN8ea1bhMLYcS80JPap/boyhU=",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.4.0.tgz",
+      "integrity": "sha512-+l482uImx5BVd6brJYlaHe2UwfKoZBqQfNp20ZmdNfsjGFTemGfqHLsXjKEW23w9R/m8WYeFc9JmIgjj6dUtAA==",
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -97,7 +236,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "requires": {
         "wrappy": "1"
@@ -106,19 +245,19 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true
     },
     "typescript": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.3.tgz",
-      "integrity": "sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
       "dev": true
     },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "string-argv",
   "description": "string-argv parses a string into an argument array to mimic process.argv. This is useful when testing Command Line Utilities that you want to pass arguments to.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "contributors": [
     {
       "name": "Michael Ferris",
@@ -17,11 +17,20 @@
     "argv"
   ],
   "scripts": {
-    "build": "tsc -p .",
+    "build": "tsc -p . & tsc -p tsconfig.commonjs.json",
     "prepublishOnly": "npm test",
     "test": "npm run build & jasmine --config=test/config.json"
   },
-  "main": "index",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js",
+      "require": "./commonjs/index.js"
+    }
+  },
+  "main": "./commonjs/index.js",
+  "module": "./index.js",
   "types": "index.d.ts",
   "engines": {
     "node": ">=0.6.19"
@@ -35,9 +44,8 @@
   },
   "homepage": "https://github.com/mccormicka/string-argv",
   "readmeFilename": "README.md",
-  "dependencies": {},
   "devDependencies": {
-    "jasmine": "^2.4.1",
-    "typescript": "^3.4.3"
+    "jasmine": "^4.4.0",
+    "typescript": "^4.8.3"
   }
 }

--- a/test/Index.spec.cjs
+++ b/test/Index.spec.cjs
@@ -1,0 +1,18 @@
+"use strict";
+var {default: StringArgv, parseArgsStringToArgv} = require("..");
+
+
+describe("Require", function () {
+  it("should correctly import both from default and from named export", function () {
+    expect(StringArgv).not.toBeNull();
+    expect(StringArgv).toBeInstanceOf(Function);
+    expect(StringArgv.length).toBe(3);
+
+    expect(parseArgsStringToArgv).not.toBeNull();
+    expect(parseArgsStringToArgv).toBeInstanceOf(Function);
+    expect(parseArgsStringToArgv.length).toBe(3);
+
+    expect(parseArgsStringToArgv).toBe(StringArgv);
+  });
+});
+

--- a/test/Index.spec.js
+++ b/test/Index.spec.js
@@ -1,31 +1,41 @@
 "use strict";
+import StringArgv, { parseArgsStringToArgv } from "../index.js";
 
-describe("SHOULD", function() {
-  it("Be able to acquire index", function() {
-    var test = require("../index");
-    expect(test).not.toBeNull();
+describe("Import", function () {
+  it("should correctly import both from default and from named export", function () {
+    expect(StringArgv).not.toBeNull();
+    expect(StringArgv).toBeInstanceOf(Function);
+    expect(StringArgv.length).toBe(3);
+
+    expect(parseArgsStringToArgv).not.toBeNull();
+    expect(parseArgsStringToArgv).toBeInstanceOf(Function);
+    expect(parseArgsStringToArgv.length).toBe(3);
+
+    expect(parseArgsStringToArgv).toBe(StringArgv);
   });
 });
 
-describe("Process ", function() {
-  var util = require("../index");
-
+describe("Process ", function () {
   function parseAndValidate(value, expectedResult, tryWithSingleQuotes) {
-    var results = util.parseArgsStringToArgv(value);
+    var results = parseArgsStringToArgv(value);
     expect(results.length).toBe(expectedResult.length);
     for (var i = 0; i < results.length; ++i) {
       expect(results[i]).toEqual(expectedResult[i]);
     }
     if (tryWithSingleQuotes) {
-      var expectedWithSingleQuotes = expectedResult.map(function(r) {
+      var expectedWithSingleQuotes = expectedResult.map(function (r) {
         return r.replace(/"/g, "'");
       });
-      parseAndValidate(value.replace(/"/g, "'"), expectedWithSingleQuotes, false);
+      parseAndValidate(
+        value.replace(/"/g, "'"),
+        expectedWithSingleQuotes,
+        false
+      );
     }
   }
 
-  it("an arguments array correctly with file and env", function(done) {
-    var results = util.parseArgsStringToArgv("-test", "node", "testing.js");
+  it("an arguments array correctly with file and env", function (done) {
+    var results = parseArgsStringToArgv("-test", "node", "testing.js");
     expect(results.length).toBe(3);
     expect(results[0]).toEqual("node");
     expect(results[1]).toEqual("testing.js");
@@ -33,102 +43,96 @@ describe("Process ", function() {
     done();
   });
 
-  it("an arguments array correctly without file and env", function(done) {
+  it("an arguments array correctly without file and env", function (done) {
     parseAndValidate("-test", ["-test"]);
     done();
   });
 
-  it("a single key", function(done) {
+  it("a single key", function (done) {
     parseAndValidate("-test", ["-test"]);
     done();
   });
 
-  it("a single key with a value", function(done) {
+  it("a single key with a value", function (done) {
     parseAndValidate("-test testing", ["-test", "testing"]);
     done();
   });
 
-  it("a single key=value", function(done) {
+  it("a single key=value", function (done) {
     parseAndValidate("-test=testing", ["-test=testing"]);
     done();
   });
 
-  it("a single value with quotes", function(done) {
+  it("a single value with quotes", function (done) {
     parseAndValidate('"test quotes"', ["test quotes"], true);
     done();
   });
 
-  it("a single value with empty quotes", function(done) {
+  it("a single value with empty quotes", function (done) {
     parseAndValidate('""', [""], true);
     done();
   });
 
-  it("a complex string with quotes", function(done) {
-    parseAndValidate('-testing test -valid=true --quotes "test quotes"', [
-      "-testing",
-      "test",
-      "-valid=true",
-      "--quotes",
-      "test quotes",
-    ], true);
+  it("a complex string with quotes", function (done) {
+    parseAndValidate(
+      '-testing test -valid=true --quotes "test quotes"',
+      ["-testing", "test", "-valid=true", "--quotes", "test quotes"],
+      true
+    );
     done();
   });
 
-  it("a complex string with empty quotes", function(done) {
-    parseAndValidate('-testing test -valid=true --quotes ""', [
-      "-testing",
-      "test",
-      "-valid=true",
-      "--quotes",
-      "",
-    ], true);
+  it("a complex string with empty quotes", function (done) {
+    parseAndValidate(
+      '-testing test -valid=true --quotes ""',
+      ["-testing", "test", "-valid=true", "--quotes", ""],
+      true
+    );
     done();
   });
 
-  it("a complex string with nested quotes", function(done) {
-    parseAndValidate('--title "Peter\'s Friends" --name \'Phil "The Power" Taylor\'', [
-      "--title",
-      "Peter's Friends",
-      "--name",
-      'Phil "The Power" Taylor',
-    ]);
+  it("a complex string with nested quotes", function (done) {
+    parseAndValidate(
+      '--title "Peter\'s Friends" --name \'Phil "The Power" Taylor\'',
+      ["--title", "Peter's Friends", "--name", 'Phil "The Power" Taylor']
+    );
     done();
   });
 
-  it("a complex key value with quotes", function(done) {
-    parseAndValidate('--name=\'Phil Taylor\' --title="Peter\'s Friends"', [
+  it("a complex key value with quotes", function (done) {
+    parseAndValidate("--name='Phil Taylor' --title=\"Peter's Friends\"", [
       "--name='Phil Taylor'",
       '--title="Peter\'s Friends"',
     ]);
     done();
   });
 
-  it("a complex key value with nested quotes", function(done) {
-    parseAndValidate('--name=\'Phil "The Power" Taylor\'', [
-      '--name=\'Phil "The Power" Taylor\''
+  it("a complex key value with nested quotes", function (done) {
+    parseAndValidate("--name='Phil \"The Power\" Taylor'", [
+      "--name='Phil \"The Power\" Taylor'",
     ]);
     done();
   });
 
-  it("nested quotes with no spaces", function(done) {
-    parseAndValidate('jake run:silent["echo 1"] --trace', [
-      "jake",
-      'run:silent["echo 1"]',
-      "--trace",
-    ], true);
+  it("nested quotes with no spaces", function (done) {
+    parseAndValidate(
+      'jake run:silent["echo 1"] --trace',
+      ["jake", 'run:silent["echo 1"]', "--trace"],
+      true
+    );
     done();
   });
 
-  it("multiple nested quotes with no spaces", function(done) {
-    parseAndValidate('jake run:silent["echo 1"]["echo 2"] --trace', [
-      "jake",
-      'run:silent["echo 1"]["echo 2"]',
-      "--trace",
-    ], true);
+  it("multiple nested quotes with no spaces", function (done) {
+    parseAndValidate(
+      'jake run:silent["echo 1"]["echo 2"] --trace',
+      ["jake", 'run:silent["echo 1"]["echo 2"]', "--trace"],
+      true
+    );
     done();
   });
 
-  it("complex multiple nested quotes", function(done) {
+  it("complex multiple nested quotes", function (done) {
     parseAndValidate('cli value("echo")[\'grep\']+"Peter\'s Friends"', [
       "cli",
       'value("echo")[\'grep\']+"Peter\'s Friends"',

--- a/test/config.json
+++ b/test/config.json
@@ -1,6 +1,4 @@
 {
-	"spec_dir": "test",
-  	"spec_files": [
-	    "**/*[sS]pec.js"
-  	]
+  "spec_dir": "test",
+  "spec_files": ["**/*[sS]pec.js", "**/*[sS]pec.cjs"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,59 @@
+{
+  "compilerOptions": {
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "incremental": true,                   /* Enable incremental compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    // "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+  }
+}

--- a/tsconfig.commonjs.json
+++ b/tsconfig.commonjs.json
@@ -2,6 +2,8 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "target": "es3",
-    "module": "ESNext"
+    "module": "commonjs",
+    "outDir": "./commonjs",
+    "declaration": false
   }
 }


### PR DESCRIPTION
Update typescript to 4.8.3 and jasmine to 4.4.0
Closes #21 


I still have little experience when in comes to ESM modules, I don't believe a library of this type should migrate to only support ESM especially that commonjs is so simple in this case.
I looked up numerous different ways to provide both and I hope the result is satisfactory.
I confirmed the typescript update makes little to no difference in the resulting javascript file which is why I'm confident about simply bumping minor version.
I don't think there's a rush to this update so I was hoping to gather a bit of feedback from the community before moving forward